### PR TITLE
Kerberos Support in Gatling

### DIFF
--- a/src/main/scala/com/datastax/gatling/stress/config/DseStressConfKeys.scala
+++ b/src/main/scala/com/datastax/gatling/stress/config/DseStressConfKeys.scala
@@ -19,6 +19,7 @@ object DseStressConfKeys {
     val defaultKeyspace = base + "defaultKeyspace"
     val defaultConsistency = base + "defaultConsistency"
     val serialConsistency = base + "serialConsistency"
+    val authMethod = base + "authMethod"
 
     object auth {
       private val auth = base + "auth."

--- a/src/main/scala/com/datastax/gatling/stress/config/DseStressConfiguration.scala
+++ b/src/main/scala/com/datastax/gatling/stress/config/DseStressConfiguration.scala
@@ -26,6 +26,7 @@ object DseStressConfiguration extends LazyLogging {
         defaultConsistency = getStringOrNone(config, DseStressConfKeys.cassandra.defaultConsistency),
         serialConsistency = getStringOrNone(config, DseStressConfKeys.cassandra.serialConsistency),
         defaultKeyspace = getStringOrNone(config, DseStressConfKeys.cassandra.defaultKeyspace),
+        authMethod = getStringOrNone(config, DseStressConfKeys.cassandra.authMethod),
 
         auth = CassandraAuthConfiguration(
           username = getStringOrNone(config, DseStressConfKeys.cassandra.auth.username),
@@ -95,6 +96,7 @@ case class CassandraConfiguration(hosts: List[String],
                                   clusterName: Option[String],
                                   defaultConsistency: Option[String],
                                   serialConsistency: Option[String],
+                                  authMethod: Option[String],
                                   auth: CassandraAuthConfiguration,
                                   graphName: Option[String],
                                   defaultKeyspace: Option[String],

--- a/src/main/scala/com/datastax/gatling/stress/libs/Cassandra.scala
+++ b/src/main/scala/com/datastax/gatling/stress/libs/Cassandra.scala
@@ -2,6 +2,7 @@ package com.datastax.gatling.stress.libs
 
 import com.datastax.driver.core.policies._
 import com.datastax.driver.core.{ConsistencyLevel, HostDistance, PoolingOptions, QueryOptions}
+import com.datastax.driver.dse.auth.DseGSSAPIAuthProvider
 import com.datastax.driver.dse.graph.GraphOptions
 import com.datastax.driver.dse.{DseCluster, DseSession}
 import com.datastax.gatling.stress.config.{CassandraConfiguration, DseStressConfiguration}
@@ -138,6 +139,12 @@ class Cassandra(conf: Config) extends LazyLogging {
     if (cassandraConf.auth.username.nonEmpty && cassandraConf.auth.password.nonEmpty) {
       logger.debug("Username and password set in configs using to connect to nodes")
       clusterBuilder.withCredentials(cassandraConf.auth.username.get, cassandraConf.auth.password.get)
+    }
+       else if (cassandraConf.authMethod.nonEmpty) {
+      if (cassandraConf.authMethod.get.equalsIgnoreCase("kerberos")) {
+        logger.debug("Using kerberos for authentication")
+        clusterBuilder.withAuthProvider(DseGSSAPIAuthProvider.builder().build())
+      }
     }
 
     // set default consistency

--- a/src/main/scala/com/datastax/gatling/stress/libs/Cassandra.scala
+++ b/src/main/scala/com/datastax/gatling/stress/libs/Cassandra.scala
@@ -139,8 +139,7 @@ class Cassandra(conf: Config) extends LazyLogging {
     if (cassandraConf.auth.username.nonEmpty && cassandraConf.auth.password.nonEmpty) {
       logger.debug("Username and password set in configs using to connect to nodes")
       clusterBuilder.withCredentials(cassandraConf.auth.username.get, cassandraConf.auth.password.get)
-    }
-       else if (cassandraConf.authMethod.nonEmpty) {
+    } else if (cassandraConf.authMethod.nonEmpty) {
       if (cassandraConf.authMethod.get.equalsIgnoreCase("kerberos")) {
         logger.debug("Using kerberos for authentication")
         clusterBuilder.withAuthProvider(DseGSSAPIAuthProvider.builder().build())


### PR DESCRIPTION
added new parameter "authMethod" for kerberos support in gatling-dse-stress


To turn ON kerberos, the application.conf file in project gatling-dse-simcatalog needs to have this additional line:
"authMethod = kerberos" in the cassandra{ } block
Eg:
cassandra {
  hosts = ["10.143.1.31","10.143.1.32"]     #hosts = ["127.0.0.1","10.143.1.31"]
  dcName = QDC1               #dc1 or QDC1
  clusterName = PERF IHUB     #Test Cluster or PERF IHUB
  defaultKeyspace = load_example
  defaultConsistency = LOCAL_QUORUM
  authMethod = kerberos     #authMethod is only used if it is set to kerberos.

  auth = {
    # username = None
    # password = None
  }
}  # end cassandra settings