### PR TITLE
wrapping Gatling.fromMap() call in a try/catch (and explicitly calling

### DIFF
--- a/src/main/scala/com/datastax/gatling/stress/Starter.scala
+++ b/src/main/scala/com/datastax/gatling/stress/Starter.scala
@@ -145,8 +145,16 @@ object Starter {
     }
 
     props.simulationClass(simList.head)
-    val res = Gatling.fromMap(props.build)
+    try {
+      val res = Gatling.fromMap(props.build)
+      System.exit(res)
+    }
+    catch{
+      case e: Exception =>
+        print(e.printStackTrace())
+        System.exit(1)
 
-    System.exit(res)
+    }
+
   }
 }


### PR DESCRIPTION
System.exit() in the catch) to eliminate issues where an exception is
thrown and the process never exits;
specifically, I have been running into issues where I get:

Simulation sims.kroger.cql.RecommendationsWriteSimulation completed in 105 seconds
Exception in thread "main" java.util.concurrent.TimeoutException: Futures timed out after [2 seconds]
at scala.concurrent.impl.Promise$DefaultPromise.ready(Promise.scala:255)
at scala.concurrent.impl.Promise$DefaultPromise.result(Promise.scala:259)
at scala.concurrent.Await$.$anonfun$result$1(package.scala:215)
at scala.concurrent.BlockContext$DefaultBlockContext$.blockOn(BlockContext.scala:53)
at scala.concurrent.Await$.result(package.scala:142)
at io.gatling.app.Gatling$.start(Gatling.scala:62)
at io.gatling.app.Gatling$.fromMap(Gatling.scala:38)
at com.datastax.gatling.stress.Starter$.run(Starter.scala:148)
at com.datastax.gatling.stress.Starter$.main(Starter.scala:66)
at com.datastax.gatling.stress.Starter.main(Starter.scala)

but the Gatling process never exits